### PR TITLE
Update gcp-restrict-machine-type.sentinel

### DIFF
--- a/bonus_lab/gcp-restrict-machine-type.sentinel
+++ b/bonus_lab/gcp-restrict-machine-type.sentinel
@@ -85,7 +85,7 @@ validate_attribute_in_list = func(type, attribute, allowed_values) {
 # Allowed GCP Machine Types
 # You must use one of these machine types to be compliant.
 allowed_types = [
-  "n1-standard-1"
+  "n1-standard-1",
   "n1-standard-2",
 ]
 


### PR DESCRIPTION
Fixing an error from TFC when doing the bonus Lab:
```
An error occurred: 1 error occurred:
	* tfc-workshop-bonuslab/gcp-restrict-machine-type.sentinel:88:19: missing ',' before newline in list literal
```