### PR TITLE
find resources only being read too

### DIFF
--- a/aws/enforce-mandatory-tags.sentinel
+++ b/aws/enforce-mandatory-tags.sentinel
@@ -2,9 +2,9 @@
 # have all mandatory tags.
 # Note that the comparison is case-sensitive since AWS tags are case-sensitive.
 
-# Import common-functions/tfplan-functions/tfplan-functions.sentinel
-# with alias "plan"
+# Import Modules
 import "tfplan-functions" as plan
+import "find-resources" as find
 
 # List of mandatory tags
 ### List of mandatory tags ###
@@ -14,7 +14,7 @@ mandatory_tags = [
 ]
 
 # Get all EC2 instances
-allEC2Instances = plan.find_resources("aws_instance")
+allEC2Instances = find.find_resources("aws_instance")
 
 # Filter to EC2 instances with violations
 # Warnings will be printed for all violations since the last parameter is true

--- a/aws/sentinel.hcl
+++ b/aws/sentinel.hcl
@@ -1,7 +1,11 @@
+policy "enforce-mandatory-tags" {
+    enforcement_level = "hard-mandatory"
+}
+
 module "tfplan-functions" {
   source = "https://raw.githubusercontent.com/hashicorp/terraform-guides/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel"
 }
 
-policy "enforce-mandatory-tags" {
-    enforcement_level = "hard-mandatory"
+module "find-resources" {
+  source = "../common-functions/find-resources.sentinel"
 }

--- a/azure/enforce-mandatory-tags.sentinel
+++ b/azure/enforce-mandatory-tags.sentinel
@@ -4,9 +4,9 @@
 # Note that the comparison is case-sensitive even though Azure tags are not.
 # If you want to allow case variations, include them in your mandatory_tags list
 
-# Import common-functions/tfplan-functions/tfplan-functions.sentinel
-# with alias "plan"
+# Import Modules
 import "tfplan-functions" as plan
+import "find-resources" as find
 
 ### List of mandatory tags ###
 mandatory_tags = [
@@ -15,7 +15,7 @@ mandatory_tags = [
 ]
 
 # Get all Azure VMs
-allAzureVMs = plan.find_resources("azurerm_virtual_machine")
+allAzureVMs = find.find_resources("azurerm_virtual_machine")
 
 # Filter to Azure VMs with violations
 # Warnings will be printed for all violations since the last parameter is true

--- a/azure/sentinel.hcl
+++ b/azure/sentinel.hcl
@@ -1,7 +1,11 @@
+policy "enforce-mandatory-tags" {
+    enforcement_level = "hard-mandatory"
+}
+
 module "tfplan-functions" {
   source = "https://raw.githubusercontent.com/hashicorp/terraform-guides/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel"
 }
 
-policy "enforce-mandatory-tags" {
-    enforcement_level = "hard-mandatory"
+module "find-resources" {
+  source = "../common-functions/find-resources.sentinel"
 }

--- a/bonus_lab/aws-restrict-all-but-ssh.sentinel
+++ b/bonus_lab/aws-restrict-all-but-ssh.sentinel
@@ -2,12 +2,10 @@
 # rules have the CIDR "0.0.0.0/0".  It covers both the aws_security_group and
 # the aws_security_group_rule resources which can both define rules.
 
-# Import the tfplan/v2 import, but use the alias "tfplan"
+# Import Modules
 import "tfplan/v2" as tfplan
-
-# Import common-functions/tfplan-functions/tfplan-functions.sentinel
-# with alias "plan"
 import "tfplan-functions" as plan
+import "find-resources" as find
 
 # Forbidden CIDRs
 # Include "null" to forbid missing or computed values
@@ -17,7 +15,9 @@ forbidden_cidrs = ["0.0.0.0/0"]
 SGIngressRules = filter tfplan.resource_changes as address, rc {
   rc.type is "aws_security_group_rule" and
   rc.mode is "managed" and rc.change.after.type is "ingress" and
-  (rc.change.actions contains "create" or rc.change.actions contains "update")
+  (rc.change.actions contains "create" or
+   rc.change.actions contains "update" or
+   rc.change.actions contains "read")
 }
 
 # Filter to Ingress Security Group Rules with violations
@@ -26,7 +26,7 @@ violatingSGRules = plan.filter_attribute_contains_items_from_list(SGIngressRules
                   "cidr_blocks",forbidden_cidrs, true)
 
 # Get all Security Groups
-allSGs = plan.find_resources("aws_security_group")
+allSGs = find.find_resources("aws_security_group")
 
 # Validate Security Groups
 violatingSGsCount = 0

--- a/bonus_lab/azure-restrict-vm-size.sentinel
+++ b/bonus_lab/azure-restrict-vm-size.sentinel
@@ -1,16 +1,16 @@
 # This policy uses the Sentinel tfplan/v2 import to require that
 # all Azure VMs have vm sizes from an allowed list
 
-# Import common-functions/tfplan-functions/tfplan-functions.sentinel
-# with alias "plan"
+# Import Modules
 import "tfplan-functions" as plan
+import "find-resources" as find
 
 # Allowed Azure VM Sizes
 # Include "null" to allow missing or computed values
 allowed_sizes = ["Standard_A1", "Standard_A2", "Standard_D1_v2", "Standard_D2_v2"]
 
 # Get all Azure VMs
-allAzureVMs = plan.find_resources("azurerm_virtual_machine")
+allAzureVMs = find.find_resources("azurerm_virtual_machine")
 
 # Filter to Azure VMs with violations
 # Warnings will be printed for all violations since the last parameter is true

--- a/bonus_lab/gcp-restrict-machine-type.sentinel
+++ b/bonus_lab/gcp-restrict-machine-type.sentinel
@@ -1,16 +1,16 @@
 # This policy uses the Sentinel tfplan/v2 import to require that
 # all GCE instances have machine types from an allowed list
 
-# Import common-functions/tfplan-functions/tfplan-functions.sentinel
-# with alias "plan"
+# Import Modules
 import "tfplan-functions" as plan
+import "find-resources" as find
 
 # Allowed GCE Instance Types
 # Include "null" to allow missing or computed values
 allowed_types = ["n1-standard-1", "n1-standard-2", "n1-standard-4"]
 
 # Get all GCE instances
-allGCEInstances = plan.find_resources("google_compute_instance")
+allGCEInstances = find.find_resources("google_compute_instance")
 
 # Filter to GCE instances with violations
 # Warnings will be printed for all violations since the last parameter is true

--- a/bonus_lab/sentinel.hcl
+++ b/bonus_lab/sentinel.hcl
@@ -1,7 +1,3 @@
-module "tfplan-functions" {
-  source = "https://raw.githubusercontent.com/hashicorp/terraform-guides/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel"
-}
-
 policy "aws-restrict-all-but-ssh" {
     enforcement_level = "hard-mandatory"
 }
@@ -12,4 +8,12 @@ policy "azure-restrict-vm-size" {
 
 policy "gcp-restrict-machine-type" {
     enforcement_level = "hard-mandatory"
+}
+
+module "tfplan-functions" {
+  source = "https://raw.githubusercontent.com/hashicorp/terraform-guides/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "find-resources" {
+  source = "../common-functions/find-resources.sentinel"
 }

--- a/common-functions/find-resources.sentinel
+++ b/common-functions/find-resources.sentinel
@@ -1,0 +1,17 @@
+# Function that finds all resources of a specified type that are being
+# created, updated, or read.
+
+# Standard tfplan/v2 import
+import "tfplan/v2" as tfplan
+
+find_resources = func(type) {
+  resources = filter tfplan.resource_changes as address, rc {
+  	rc.type is type and
+  	rc.mode is "managed" and
+  	(rc.change.actions contains "create" or
+     rc.change.actions contains "update" or
+     rc.change.actions contains "read")
+  }
+
+  return resources
+}

--- a/gcp/enforce-mandatory-labels.sentinel
+++ b/gcp/enforce-mandatory-labels.sentinel
@@ -4,9 +4,9 @@
 # Note that the comparison is case-sensitive but also that GCP labels
 # are only allowed to contain lowercase letters, numbers, and dashes.
 
-# Import common-functions/tfplan-functions/tfplan-functions.sentinel
-# with alias "plan"
+# Import Modules
 import "tfplan-functions" as plan
+import "find-resources" as find
 
 ### List of mandatory labels ###
 mandatory_labels = [
@@ -15,7 +15,7 @@ mandatory_labels = [
 ]
 
 # Get all GCP compute instances
-allGCEInstances = plan.find_resources("google_compute_instance")
+allGCEInstances = find.find_resources("google_compute_instance")
 
 # Filter to GCP compute instances with violations
 # Warnings will be printed for all violations since the last parameter is true

--- a/gcp/sentinel.hcl
+++ b/gcp/sentinel.hcl
@@ -1,7 +1,11 @@
+policy "enforce-mandatory-labels" {
+    enforcement_level = "hard-mandatory"
+}
+
 module "tfplan-functions" {
   source = "https://raw.githubusercontent.com/hashicorp/terraform-guides/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel"
 }
 
-policy "enforce-mandatory-labels" {
-    enforcement_level = "hard-mandatory"
+module "find-resources" {
+  source = "../common-functions/find-resources.sentinel"
 }


### PR DESCRIPTION
Update the Sentinel policies for the TFC workshops to also act against resources that are only being read.
This is desirable because the relevant resources have already been created but the first apply after enabling Sentinel does not have any changes to them.